### PR TITLE
Disable scrolling and zooming

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,15 +2,38 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, maximum-scale=1.0" />
   <title>Vercel V1</title>
   <style>
-    body { font-family: sans-serif; padding: 2rem; }
+    html, body {
+      overflow: hidden;
+      height: 100%;
+      margin: 0;
+      overscroll-behavior: none;
+    }
+
+    body {
+      font-family: sans-serif;
+      padding: 2rem;
+      position: fixed;
+      width: 100%;
+    }
     h1 { color: #333; }
   </style>
 </head>
 <body>
   <h1>Welcome to Vercel V1</h1>
   <p>Your basic Vercel project is set up!</p>
+  <script>
+    const preventScroll = (e) => e.preventDefault();
+    window.addEventListener('wheel', preventScroll, { passive: false });
+    window.addEventListener('touchmove', preventScroll, { passive: false });
+    window.addEventListener('keydown', (e) => {
+      const keys = ['ArrowUp', 'ArrowDown', 'PageUp', 'PageDown', 'Home', 'End', 'Space'];
+      if (keys.includes(e.key)) {
+        e.preventDefault();
+      }
+    });
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- prevent zooming by setting user-scalable=no and maximum-scale in viewport meta tag
- hide overflow and margins on html and body to remove scrollbars
- block wheel, touch, and key-based scrolling to fully prevent page movement

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9cf03f7f88323bd3e642d1ffce52e