### PR TITLE
Hide scrollbar on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,12 @@
       height: 100vh;
       margin: 0;
       overscroll-behavior: none;
+      scrollbar-width: none; /* Firefox */
+    }
+
+    html::-webkit-scrollbar,
+    body::-webkit-scrollbar {
+      display: none; /* Chrome, Safari and Opera */
     }
 
     body {


### PR DESCRIPTION
## Summary
- hide mobile scrollbars using CSS for WebKit and Firefox

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9f83770a48323875400d5afe1caa3