### PR TITLE
feat: use visual viewport for box sizing

### DIFF
--- a/boxes.js
+++ b/boxes.js
@@ -32,8 +32,11 @@ export function createBox({
   element.style.background = background;
 
   function resize() {
-    element.style.width = `${window.innerWidth + offset - left - right}px`;
-    element.style.height = `${window.innerHeight + offset - top - bottom}px`;
+    const viewportWidth = window.visualViewport?.width ?? window.innerWidth;
+    const viewportHeight = window.visualViewport?.height ?? window.innerHeight;
+
+    element.style.width = `${viewportWidth + offset - left - right}px`;
+    element.style.height = `${viewportHeight + offset - top - bottom}px`;
   }
 
   resize();


### PR DESCRIPTION
## Summary
- size boxes based on `window.visualViewport` with fallback to `window.innerWidth`/`window.innerHeight`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9fde1fbc0832391a902aabce3ab32