### PR TITLE
Ensure mobile boxes span entire screen

### DIFF
--- a/boxes.js
+++ b/boxes.js
@@ -18,22 +18,22 @@ export function createBox({
   offset = 0,
   padding = 0,
   background = 'lightgray',
-  top = 10,
-  right = 10,
-  bottom = 10,
-  left = 10,
+  top = 0,
+  right = 0,
+  bottom = 0,
+  left = 0,
 } = {}) {
   const element = document.createElement('div');
 
   element.style.position = 'absolute';
-  element.style.top = `${top}px`;
   element.style.left = `${left}px`;
   element.style.padding = `${padding}px`;
   element.style.background = background;
 
   function resize() {
-    element.style.width = `${window.innerWidth + offset - left - right}px`;
-    element.style.height = `${window.innerHeight + offset - top - bottom}px`;
+    element.style.top = `calc(${top}px - env(safe-area-inset-top))`;
+    element.style.width = `calc(100vw + ${offset}px - ${left + right}px)`;
+    element.style.height = `calc(100vh + env(safe-area-inset-top) + env(safe-area-inset-bottom) + ${offset}px - ${top + bottom}px)`;
   }
 
   resize();

--- a/index.html
+++ b/index.html
@@ -2,12 +2,13 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, maximum-scale=1.0" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, maximum-scale=1.0, viewport-fit=cover" />
   <title>Vercel V1</title>
   <style>
     html, body {
       overflow: hidden;
       height: 100vh;
+      height: 100dvh;
       margin: 0;
       overscroll-behavior: none;
       scrollbar-width: none; /* Firefox */


### PR DESCRIPTION
## Summary
- Use safe-area insets and viewport units so boxes fill the full height on mobile
- Include `viewport-fit=cover` and `100dvh` in layout to support edge-to-edge rendering

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9fffca0108323ba7a48bb8168cabd