### PR TITLE
fix: extend grid to full device height

### DIFF
--- a/Seite1Grid.css
+++ b/Seite1Grid.css
@@ -1,21 +1,20 @@
 /* Dynamic grid container with adjustable spacing */
 .seite1-grid {
-  /* Spacing variables for each side */
-  --spacing-top: 1rem;
+  /* Horizontal spacing variables */
   --spacing-right: 1rem;
-  --spacing-bottom: 1rem;
   --spacing-left: 1rem;
 
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
   gap: 1rem;
-  margin: var(--spacing-top) var(--spacing-right) var(--spacing-bottom) var(--spacing-left);
+  margin: 0 var(--spacing-right) 0 var(--spacing-left);
   padding: env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);
   width: calc(100vw - var(--spacing-left) - var(--spacing-right));
-  /* Use dynamic viewport units to avoid gaps on mobile browsers */
-  height: calc(100svh - var(--spacing-top) - var(--spacing-bottom));
-  height: calc(100dvh - var(--spacing-top) - var(--spacing-bottom));
-  height: calc(100lvh - var(--spacing-top) - var(--spacing-bottom));
+  /* Use dynamic viewport units to ensure full height on mobile browsers */
+  min-height: 100vh;   /* Fallback for older browsers */
+  min-height: 100svh;  /* Small viewport height */
+  min-height: 100dvh;  /* Dynamic viewport height */
+  min-height: 100lvh;  /* Large viewport height */
   box-sizing: border-box;
 
   /* Debug styles */

--- a/index.html
+++ b/index.html
@@ -8,11 +8,14 @@
     <style>
     html, body {
       overflow: hidden;
-      height: 100vh;
-      height: 100dvh;
       margin: 0;
       overscroll-behavior: none;
       scrollbar-width: none; /* Firefox */
+      /* Allow the page to cover the full device height */
+      min-height: 100vh;   /* Fallback for older browsers */
+      min-height: 100svh;  /* Small viewport height */
+      min-height: 100dvh;  /* Dynamic viewport height */
+      min-height: 100lvh;  /* Large viewport height */
     }
 
     html::-webkit-scrollbar,


### PR DESCRIPTION
## Summary
- ensure grid uses dynamic viewport units and no vertical margin
- allow page to expand to full device height for notch and toolbars

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba1f5fef58832393e2bfeb0ddc3933