### PR TITLE
Ensure grid fills entire mobile viewport

### DIFF
--- a/Seite1Grid.css
+++ b/Seite1Grid.css
@@ -9,13 +9,19 @@
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
   gap: 1rem;
-  margin: var(--spacing-top) var(--spacing-right) var(--spacing-bottom) var(--spacing-left);
-  padding: env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);
-  width: calc(100vw - var(--spacing-left) - var(--spacing-right));
+  /* Combine custom spacing with safe-area insets so the orange
+     background always covers the full device viewport. */
+  padding:
+    calc(env(safe-area-inset-top) + var(--spacing-top))
+    calc(env(safe-area-inset-right) + var(--spacing-right))
+    calc(env(safe-area-inset-bottom) + var(--spacing-bottom))
+    calc(env(safe-area-inset-left) + var(--spacing-left));
+  width: 100vw;
   /* Use dynamic viewport units to avoid gaps on mobile browsers */
-  height: calc(100svh - var(--spacing-top) - var(--spacing-bottom));
-  height: calc(100dvh - var(--spacing-top) - var(--spacing-bottom));
-  height: calc(100lvh - var(--spacing-top) - var(--spacing-bottom));
+  height: 100vh;
+  height: 100svh;
+  height: 100dvh;
+  height: 100lvh;
   box-sizing: border-box;
 
   /* Debug styles */


### PR DESCRIPTION
## Summary
- adjust grid layout so background spans full viewport height on mobile devices

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ba1f5fef58832393e2bfeb0ddc3933