### PR TITLE
Ensure grid fills entire mobile viewport

### DIFF
--- a/Seite1Grid.css
+++ b/Seite1Grid.css
@@ -9,13 +9,21 @@
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
   gap: 1rem;
-  margin: var(--spacing-top) var(--spacing-right) var(--spacing-bottom) var(--spacing-left);
-  padding: env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);
-  width: calc(100vw - var(--spacing-left) - var(--spacing-right));
-  /* Use dynamic viewport units to avoid gaps on mobile browsers */
-  height: calc(100svh - var(--spacing-top) - var(--spacing-bottom));
-  height: calc(100dvh - var(--spacing-top) - var(--spacing-bottom));
-  height: calc(100lvh - var(--spacing-top) - var(--spacing-bottom));
+  /* Combine custom spacing with safe-area insets so the orange
+     background always covers the full device viewport. */
+  padding:
+    calc(env(safe-area-inset-top) + var(--spacing-top))
+    calc(env(safe-area-inset-right) + var(--spacing-right))
+    calc(env(safe-area-inset-bottom) + var(--spacing-bottom))
+    calc(env(safe-area-inset-left) + var(--spacing-left));
+  width: 100%;
+  /* Use dynamic viewport units and fallbacks so the grid spans the
+     full available height across browsers without being cut off by
+     notches or browser chrome. */
+  min-height: 100vh;
+  min-height: 100svh;
+  min-height: 100dvh;
+  min-height: 100lvh;
   box-sizing: border-box;
 
   /* Debug styles */

--- a/index.html
+++ b/index.html
@@ -8,11 +8,16 @@
     <style>
     html, body {
       overflow: hidden;
-      height: 100vh;
-      height: 100dvh;
       margin: 0;
       overscroll-behavior: none;
       scrollbar-width: none; /* Firefox */
+      /* Allow the page and grid background to stretch to the full
+         dynamic viewport height on mobile without being constrained by
+         browser UI. */
+      min-height: 100vh;
+      min-height: 100svh;
+      min-height: 100dvh;
+      min-height: 100lvh;
     }
 
     html::-webkit-scrollbar,


### PR DESCRIPTION
## Summary
- switch grid to min-height dynamic viewport units so background stretches past notches and browser chrome
- apply same min-height fallbacks to html and body for consistent full-height layout

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba1f5fef58832393e2bfeb0ddc3933