### PR TITLE
Ensure grid fills entire mobile viewport

### DIFF
--- a/Seite1Grid.css
+++ b/Seite1Grid.css
@@ -9,13 +9,17 @@
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
   gap: 1rem;
-  margin: var(--spacing-top) var(--spacing-right) var(--spacing-bottom) var(--spacing-left);
-  padding: env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);
-  width: calc(100vw - var(--spacing-left) - var(--spacing-right));
-  /* Use dynamic viewport units to avoid gaps on mobile browsers */
-  height: calc(100svh - var(--spacing-top) - var(--spacing-bottom));
-  height: calc(100dvh - var(--spacing-top) - var(--spacing-bottom));
-  height: calc(100lvh - var(--spacing-top) - var(--spacing-bottom));
+  /* Combine custom spacing with safe-area insets so the orange
+     background always covers the full device viewport. */
+  padding:
+    calc(env(safe-area-inset-top) + var(--spacing-top))
+    calc(env(safe-area-inset-right) + var(--spacing-right))
+    calc(env(safe-area-inset-bottom) + var(--spacing-bottom))
+    calc(env(safe-area-inset-left) + var(--spacing-left));
+  width: 100vw;
+  /* Track the real viewport height via a custom property to avoid
+     clipping behind notches or browser UI on mobile devices. */
+  height: var(--app-height, 100vh);
   box-sizing: border-box;
 
   /* Debug styles */

--- a/index.html
+++ b/index.html
@@ -8,8 +8,7 @@
     <style>
     html, body {
       overflow: hidden;
-      height: 100vh;
-      height: 100dvh;
+      height: var(--app-height, 100vh);
       margin: 0;
       overscroll-behavior: none;
       scrollbar-width: none; /* Firefox */
@@ -34,6 +33,13 @@
       <h1>Welcome to Vercel V1</h1>
       <p>Your basic Vercel project is set up!</p>
     </div>
+    <script>
+      const setAppHeight = () => {
+        document.documentElement.style.setProperty('--app-height', `${window.innerHeight}px`);
+      };
+      window.addEventListener('resize', setAppHeight);
+      setAppHeight();
+    </script>
   </body>
 </html>
 


### PR DESCRIPTION
## Summary
- calculate actual viewport height with JavaScript and expose it via `--app-height`
- use custom property to size `html`, `body`, and the orange grid so it spans the full screen on mobile devices

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba1f5fef58832393e2bfeb0ddc3933