### PR TITLE
Honor safe area in Box1 top offset

### DIFF
--- a/Box1.css
+++ b/Box1.css
@@ -1,11 +1,12 @@
 .box1 {
   position: fixed;
-  top: 10;
+  /* Offset overlay from the top while honoring mobile safe areas */
+  top: calc(env(safe-area-inset-top, 0px) + 10px);
   right: 0;
   bottom: 0;
   left: 0;
   background-color: rgba(0, 123, 255, 0.9); /* bright color overlay */
   z-index: 9999;
   /* Account for notches and safe areas on mobile devices */
-  padding: env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);
+  padding: 0 env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);
 }


### PR DESCRIPTION
## Summary
- offset Box1 overlay by env(safe-area-inset-top) so spacing respects mobile notches
- remove top safe-area padding to avoid doubling the inset

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68baa0bb1d90832391428130e5c0733b