### PR TITLE
Add notch-safe full-screen box example

### DIFF
--- a/Box1.html
+++ b/Box1.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+  <title>Box1</title>
+  <style>
+    html, body {
+      height: 100%;
+      margin: 0;
+    }
+    body {
+      background: #222;
+    }
+    .fullscreen-box {
+      box-sizing: border-box;
+      width: 100%;
+      height: 100%;
+      padding: 10px;
+      background: orange;
+      background-clip: content-box;
+    }
+  </style>
+</head>
+<body>
+  <div class="fullscreen-box">
+    <!-- Inhalt kann hier platziert werden -->
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `Box1.html` example showing full-screen box with 10px padding and `viewport-fit=cover`
- color the full-screen box orange for better visibility

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bab0af5e448323b6ebcee6c0a52e5b