### PR TITLE
Add scrollable full-screen sections with navigation buttons

### DIFF
--- a/Scroll1.css
+++ b/Scroll1.css
@@ -1,0 +1,9 @@
+.Scroll1MainBox {
+  width: 100vw;
+  height: 100vh;
+  background-color: #ff6961;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex: 0 0 100vw;
+}

--- a/Scroll2.css
+++ b/Scroll2.css
@@ -1,0 +1,9 @@
+.Scroll2MainBox {
+  width: 100vw;
+  height: 100vh;
+  background-color: #77dd77;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex: 0 0 100vw;
+}

--- a/Scroll3.css
+++ b/Scroll3.css
@@ -1,0 +1,9 @@
+.Scroll3MainBox {
+  width: 100vw;
+  height: 100vh;
+  background-color: #aec6cf;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex: 0 0 100vw;
+}

--- a/Scroll4.css
+++ b/Scroll4.css
@@ -1,0 +1,9 @@
+.Scroll4MainBox {
+  width: 100vw;
+  height: 100vh;
+  background-color: #fdfd96;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex: 0 0 100vw;
+}

--- a/buttons.js
+++ b/buttons.js
@@ -1,0 +1,19 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const container = document.getElementById('scroll-container');
+  const buttonContainer = document.createElement('div');
+  buttonContainer.id = 'button-container';
+
+  [1, 2, 3, 4].forEach(num => {
+    const btn = document.createElement('button');
+    btn.textContent = num;
+    btn.addEventListener('click', () => {
+      container.scrollTo({
+        left: (num - 1) * window.innerWidth,
+        behavior: 'smooth'
+      });
+    });
+    buttonContainer.appendChild(btn);
+  });
+
+  document.body.appendChild(buttonContainer);
+});

--- a/index.html
+++ b/index.html
@@ -4,43 +4,19 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>Vercel V1</title>
-    <style>
-    html, body {
-      overflow: hidden;
-      margin: 0;
-      overscroll-behavior: none;
-      scrollbar-width: none; /* Firefox */
-      /* Allow the page and grid background to stretch to the full
-         dynamic viewport height on mobile without being constrained by
-         browser UI. */
-      min-height: 100vh;
-      min-height: 100svh;
-      min-height: 100dvh;
-      min-height: 100lvh;
-    }
-
-    html::-webkit-scrollbar,
-    body::-webkit-scrollbar {
-      display: none; /* Chrome, Safari and Opera */
-    }
-
-      body {
-        position: fixed;
-        width: 100%;
-        font-family: sans-serif;
-        background-color: #f0f0f0;
-        background-image:
-          radial-gradient(circle at 20px 20px, rgba(0, 0, 0, 0.1) 8px, transparent 9px),
-          radial-gradient(circle at 60px 60px, rgba(0, 0, 0, 0.1) 8px, transparent 9px);
-        background-size: 80px 80px;
-      }
-      h1 { color: #333; }
-    </style>
+    <link rel="stylesheet" href="Scroll1.css" />
+    <link rel="stylesheet" href="Scroll2.css" />
+    <link rel="stylesheet" href="Scroll3.css" />
+    <link rel="stylesheet" href="Scroll4.css" />
+    <link rel="stylesheet" href="placement.css" />
   </head>
   <body>
-    <div>
-      <h1>Welcome to Vercel V1</h1>
-      <p>Your basic Vercel project is set up!</p>
+    <div id="scroll-container">
+      <div class="Scroll1MainBox"><h1>Box 1</h1></div>
+      <div class="Scroll2MainBox"><h1>Box 2</h1></div>
+      <div class="Scroll3MainBox"><h1>Box 3</h1></div>
+      <div class="Scroll4MainBox"><h1>Box 4</h1></div>
     </div>
+    <script src="buttons.js"></script>
   </body>
 </html>

--- a/placement.css
+++ b/placement.css
@@ -1,0 +1,32 @@
+html, body {
+  margin: 0;
+  padding: 0;
+  overflow: hidden;
+}
+
+#scroll-container {
+  display: flex;
+  height: 100vh;
+  width: 400vw;
+  overflow-x: scroll;
+  overflow-y: hidden;
+  scroll-behavior: smooth;
+  scroll-snap-type: x mandatory;
+  scrollbar-width: none;
+}
+
+#scroll-container::-webkit-scrollbar {
+  display: none;
+}
+
+#button-container {
+  position: fixed;
+  top: 10px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 1000;
+}
+
+#button-container button {
+  margin: 0 5px;
+}


### PR DESCRIPTION
## Summary
- add Scroll1-Scroll4 styles for full-screen colored sections
- horizontally align sections and hide scrollbars
- add navigation buttons that smoothly scroll to each section

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bacacbc6948323b2f9993ea7fe1ca6