### PR TITLE
Disable manual scrolling and zoom

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover" />
     <title>Vercel V1</title>
     <link rel="stylesheet" href="Scroll1.css" />
     <link rel="stylesheet" href="Scroll2.css" />

--- a/placement.css
+++ b/placement.css
@@ -2,14 +2,15 @@ html, body {
   margin: 0;
   padding: 0;
   overflow: hidden;
+  touch-action: none;
+  overscroll-behavior: none;
 }
 
 #scroll-container {
   display: flex;
   height: 100vh;
   width: 100vw;
-  overflow-x: scroll;
-  overflow-y: hidden;
+  overflow: hidden;
   scroll-behavior: smooth;
   scroll-snap-type: x mandatory;
   scrollbar-width: none;


### PR DESCRIPTION
## Summary
- block manual scrolling and overscroll behaviour for the entire page
- simplify scroll container styles so scrollbars stay hidden

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68badb40727c83239e47f0a7f017020f