### PR TITLE
Respect safe-area insets for mobile layout

### DIFF
--- a/placement.css
+++ b/placement.css
@@ -24,7 +24,7 @@ html, body {
 
 #button-container {
   position: fixed;
-  top: 10px;
+  top: calc(env(safe-area-inset-top) + 10px);
   left: 50%;
   transform: translateX(-50%);
   z-index: 1000;
@@ -33,3 +33,15 @@ html, body {
 #button-container button {
   margin: 0 5px;
 }
+
+.Scroll1MainBox,
+.Scroll2MainBox,
+.Scroll3MainBox,
+.Scroll4MainBox {
+  box-sizing: border-box;
+  padding-top: env(safe-area-inset-top);
+  padding-bottom: env(safe-area-inset-bottom);
+  padding-left: env(safe-area-inset-left);
+  padding-right: env(safe-area-inset-right);
+}
+


### PR DESCRIPTION
## Summary
- Avoid notch overlap on mobile by offsetting button container with safe-area insets
- Add safe-area padding to scroll sections so background extends to device edges

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68badf8fa22c8323b0c52f69795b8826