### PR TITLE
fix: adjust layout for mobile safe areas

### DIFF
--- a/Scroll1.css
+++ b/Scroll1.css
@@ -1,9 +1,13 @@
 .Scroll1MainBox {
   width: 100vw;
   height: 100vh;
+  height: 100dvh;
   background-color: #ff6961;
   display: flex;
   justify-content: center;
   align-items: center;
   flex: 0 0 100vw;
+  padding-top: env(safe-area-inset-top);
+  padding-bottom: env(safe-area-inset-bottom);
+  box-sizing: border-box;
 }

--- a/Scroll2.css
+++ b/Scroll2.css
@@ -1,9 +1,13 @@
 .Scroll2MainBox {
   width: 100vw;
   height: 100vh;
+  height: 100dvh;
   background-color: #77dd77;
   display: flex;
   justify-content: center;
   align-items: center;
   flex: 0 0 100vw;
+  padding-top: env(safe-area-inset-top);
+  padding-bottom: env(safe-area-inset-bottom);
+  box-sizing: border-box;
 }

--- a/Scroll3.css
+++ b/Scroll3.css
@@ -1,9 +1,13 @@
 .Scroll3MainBox {
   width: 100vw;
   height: 100vh;
+  height: 100dvh;
   background-color: #aec6cf;
   display: flex;
   justify-content: center;
   align-items: center;
   flex: 0 0 100vw;
+  padding-top: env(safe-area-inset-top);
+  padding-bottom: env(safe-area-inset-bottom);
+  box-sizing: border-box;
 }

--- a/Scroll4.css
+++ b/Scroll4.css
@@ -1,9 +1,13 @@
 .Scroll4MainBox {
   width: 100vw;
   height: 100vh;
+  height: 100dvh;
   background-color: #fdfd96;
   display: flex;
   justify-content: center;
   align-items: center;
   flex: 0 0 100vw;
+  padding-top: env(safe-area-inset-top);
+  padding-bottom: env(safe-area-inset-bottom);
+  box-sizing: border-box;
 }

--- a/placement.css
+++ b/placement.css
@@ -9,6 +9,7 @@ html, body {
 #scroll-container {
   display: flex;
   height: 100vh;
+  height: 100dvh;
   width: 100vw;
   overflow-x: hidden;
   overflow-y: hidden;
@@ -24,7 +25,7 @@ html, body {
 
 #button-container {
   position: fixed;
-  top: 10px;
+  top: calc(env(safe-area-inset-top) + 10px);
   left: 50%;
   transform: translateX(-50%);
   z-index: 1000;


### PR DESCRIPTION
## Summary
- ensure scroll sections fill full device screen height
- pad each section for top and bottom safe areas
- keep navigation buttons clear of notches

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68badf8fa22c8323b0c52f69795b8826